### PR TITLE
Fix use of undefined function

### DIFF
--- a/elisp-slime-nav.el
+++ b/elisp-slime-nav.el
@@ -28,6 +28,8 @@
 ;;
 ;;; Code:
 
+(require 'help-mode)
+
 (defvar elisp-slime-nav-mode-map (make-keymap))
 
 ;;;###autoload


### PR DESCRIPTION
`help-xref-interned` is not autoloaded so help-mode needs to be loaded explicitly.
