### PR TITLE
Fix typito in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ code such as the following to your emacs startup file:
 
 ``` lisp
 (dolist (hook '(emacs-lisp-mode-hook ielm-mode-hook))
-  (add-hook hook 'turn-onelisp-slime-nav-mode))
+  (add-hook hook 'turn-on-elisp-slime-nav-mode))
 ```
 
 


### PR DESCRIPTION
**typito** _n._ - a tiny typo, often trivial.

> If users of open-source libraries correct **typitos** and other
> little errors themselves, the creators and maintainers are free
> to spend their creative energies elsewhere.
