### PR TITLE
Allow to search tags table first

### DIFF
--- a/elisp-slime-nav.el
+++ b/elisp-slime-nav.el
@@ -34,6 +34,25 @@
 (require 'etags)
 (require 'help-mode)
 
+(defgroup elisp-slime-nav nil
+  "Tag navigation in Emacs Lisp"
+  :prefix "elisp-slime-nav-"
+  :group 'tools
+  :link '(url-link :tag "Github" "https://github.com/purcell/elisp-slime-nav")
+  :link '(emacs-commentary-link "elisp-slime-nav"))
+
+(defcustom elisp-slime-nav-try-tags-first nil
+  "Whether to try `find-tag' first.
+
+When non-nil, try to find symbols in the tag table first, before
+trying to find the source of the current definition of the tag.
+See Info Node `(emacs)Tags' for more information about tag
+tables."
+  :group 'elisp-slime-nav
+  :type 'boolean
+  :safe #'booleanp
+  :package-version '(elisp-slime-nav . "0.7"))
+
 (defvar elisp-slime-nav-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "M-.")         'elisp-slime-nav-find-elisp-thing-at-point)
@@ -69,6 +88,28 @@ If `current-prefix-arg' is not nil, the user is prompted for the symbol."
                            nil t at-point)
         at-point)))
 
+(defun elisp-slime-nav--find-elisp-thing (thing)
+  "Jump to a elisp THING.
+
+THING is a string or symbol, denoting a function, variable,
+library or face.
+
+Jump to the definition of THING."
+  (let ((sym (intern thing)))
+      (message "Searching for %s..." (pp-to-string sym))
+      (ring-insert find-tag-marker-ring (point-marker))
+      (cond
+       ((fboundp sym) (find-function sym))
+       ((boundp sym) (find-variable sym))
+       ((or (featurep sym) (locate-library thing))
+        (find-library thing))
+       ((facep sym)
+        (find-face-definition sym))
+       (:else
+        (progn
+          (pop-tag-mark)
+          (error "Don't know how to find '%s'" sym))))))
+
 ;;;###autoload
 (defun elisp-slime-nav-find-elisp-thing-at-point (sym-name)
   "Jump to the elisp thing at point, be it a function, variable, library or face.
@@ -76,20 +117,11 @@ With a prefix arg, prompt for the symbol to jump to.
 Argument SYM-NAME thing to find."
   (interactive (list (elisp-slime-nav--read-symbol-at-point)))
   (when sym-name
-    (let ((sym (intern sym-name)))
-      (message "Searching for %s..." (pp-to-string sym))
-      (ring-insert find-tag-marker-ring (point-marker))
-      (cond
-       ((fboundp sym) (find-function sym))
-       ((boundp sym) (find-variable sym))
-       ((or (featurep sym) (locate-library sym-name))
-        (find-library sym-name))
-       ((facep sym)
-        (find-face-definition sym))
-       (:else
-        (progn
-          (pop-tag-mark)
-          (error "Don't know how to find '%s'" sym)))))))
+    (if elisp-slime-nav-try-tags-first
+        (condition-case nil
+            (find-tag sym-name)
+          (error (elisp-slime-nav--find-elisp-thing sym-name)))
+      (elisp-slime-nav--find-elisp-thing sym-name))))
 
 ;;;###autoload
 (defun elisp-slime-nav-describe-elisp-thing-at-point (sym-name)


### PR DESCRIPTION
Add new user option elisp-slime-nav-try-tags-first.  When non-nil, try to find the symbol with find-tag first.  For compatibility, this option defaults to nil.

Still lacks doc in README, but I'm opening the PR anyway to get your feedback first.

When working on Flycheck, I want to jump to the definition as present in the current source code tree.  Without this option, however, elisp-slime-nav jumps to the definition from the Flycheck package I installed for daily use.

To make elisp-slime-nav use the tags from the Flycheck source code, I have to eval the Flycheck buffer first, which I often forget, and often don't even want to, for instance, if the Flycheck source code is currently in a broken state, because I haven't finished implementing a new feature yet.

With this option however, I can just generate a tag table for Flycheck (I use `projectile-regenerate-tags` for this purpose), and use elisp-slime-nav to navigate my Flycheck source code.  But for symbols from other libraries, elisp-slime-nav will still jump to the current definition.
