### PR TITLE
Read a string when symbol at point is null

### DIFF
--- a/elisp-slime-nav.el
+++ b/elisp-slime-nav.el
@@ -63,7 +63,7 @@
 If `current-prefix-arg' is not nil, the user is prompted for the symbol."
   (let* ((sym-at-point (symbol-at-point))
            (at-point (and sym-at-point (symbol-name sym-at-point))))
-      (if current-prefix-arg
+      (if (or current-prefix-arg (null at-point))
           (completing-read "Symbol: "
                            (elisp-slime-nav--all-navigable-symbol-names)
                            nil t at-point)


### PR DESCRIPTION
Hi,

Currently, if symbol at point is null, a following error occurs:

```
elisp-slime-nav-describe-elisp-thing-at-point: Wrong type argument: stringp, nil
```

This patch make to read a string when symbol at point is null.

Thank you for making this cool software. I use it every day.

Cheers,

-Yasuyuki
